### PR TITLE
商品一覧ページのレイアウトの調整

### DIFF
--- a/app/views/admins/items/index.html.erb
+++ b/app/views/admins/items/index.html.erb
@@ -24,10 +24,14 @@
      <tbody>
       <td><%= item.id %></td>
       <td><%= link_to item.name, admins_item_path(item.id) %></td>
-      <td><%= item.price %></td>
+      <td>¥<%= item.price %></td>
       <td><%= item.genre.name %></td>
       <td>
-       販売中
+        <% if item.is_active == true %>
+          <p class = "text-success">販売中</p>
+        <% elsif item.is_active == false %>
+          <p class = "text-secondary">販売停止中</p>
+        <% end %>
       </td>
      </tbody>
      <% end %>

--- a/app/views/public/cart_items/index.html.erb
+++ b/app/views/public/cart_items/index.html.erb
@@ -9,7 +9,7 @@
 　　<div class="row" style="width:90%; margin:0 auto;">
       <div class="table-responsive col-md-11">
         <div style="margin-left:85%;">
-          <%= link_to "カートを空にする", destroy_all_cart_items_path, method: :delete, class: "btn btn-sm btn-danger" %>
+          <%= link_to "カートを空にする", destroy_all_cart_items_path, method: :delete, data: { confirm: 'カートを空にしますか？' }, class: "btn btn-sm btn-danger" %>
         </div>
         <table class="table table-bordered ">
           <thead class="thead-light">

--- a/app/views/public/items/index.html.erb
+++ b/app/views/public/items/index.html.erb
@@ -12,26 +12,26 @@
             <tbody>
               <tr>
                 <td>
-    　            <%= link_to item_path(item.id) do %>
-                  <%= attachment_image_tag item, :image, :fill, 150, 150, format: 'jpeg' %>
-          　　      <% end %>
-                  <%= link_to item.name, item_path(item.id) %><br>
-                  <% if item.is_active == true %>
-                    ¥<%= item.price %>
-                  <% elsif item.is_active == false %>
-          　        売り切れ中
-                  <% end %>
+      　            <div class="card-deck" style="width:18rem">
+                    <div class="card">
+                      <%= link_to item_path(item.id) do %>
+                        <%= attachment_image_tag(item, :image, size: "255x240") %>
+                      <% end %>
+                        <%= link_to item.name, item_path(item.id) %>
+                      <% if item.is_active == true %>
+                        ¥<%= item.price %>
+                      <% elsif item.is_active == false %>
+                        売り切れ中
+                      <% end %>
+                    </div>
+                  </div>
                 </td>
               </tr>
-          </tbody>
-        </table>
-        <% end %>
-      </div>
-  　</div>
-  　<div class="row">
-      <div class="text-center" style="margin:0 auto;">
-       <%= paginate @items %>
-      </div>
+            </tbody>
+          </table>
+          <% end %>
+        </div>
+        <br>
+      <%= paginate @items %>
     </div>
   </div>
-


### PR DESCRIPTION
##顧客側、商品一覧、カートページを主に変更
-カートページのカートを空にするボタンの確認ダイアログを表示
-管理者側の商品の一覧ページの￥とステータスの表示を追加
-顧客側の商品一覧ページのレイアウトをカードに変更し、大きさを調整
